### PR TITLE
CSS display now none/block on open/closed tabs

### DIFF
--- a/demo/src/tabulous.css
+++ b/demo/src/tabulous.css
@@ -78,6 +78,7 @@ p {
 	filter: alpha(opacity=0);
 	filter: alpha(opacity=0);
 	opacity: 0;
+	display: none;
 }
 
 .showscale {
@@ -89,6 +90,7 @@ p {
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)";
 	filter: alpha(opacity=100);
 	opacity: 1;
+	display: block;
 
 	-webkit-transition-delay: .3s;
 	-moz-transition-delay: .3s;


### PR DESCRIPTION
Prevents chrome and other browsers from having issues with an invisible tab appearing over the top of the visible tab. This allows links to work within the tab. Other plugins such as page numbering within the tabs will also play much nicer.
